### PR TITLE
Build task management settings panel

### DIFF
--- a/lib/src/bloc/routine_events.dart
+++ b/lib/src/bloc/routine_events.dart
@@ -55,3 +55,28 @@ class MarkTaskDone extends RoutineEvent {
 class GoToPreviousTask extends RoutineEvent {
   const GoToPreviousTask();
 }
+
+class UpdateTask extends RoutineEvent {
+  const UpdateTask({required this.index, required this.task});
+  final int index;
+  final TaskModel task;
+
+  @override
+  List<Object?> get props => [index, task];
+}
+
+class DuplicateTask extends RoutineEvent {
+  const DuplicateTask(this.index);
+  final int index;
+
+  @override
+  List<Object?> get props => [index];
+}
+
+class DeleteTask extends RoutineEvent {
+  const DeleteTask(this.index);
+  final int index;
+
+  @override
+  List<Object?> get props => [index];
+}

--- a/test/task_management_screen_simple_test.dart
+++ b/test/task_management_screen_simple_test.dart
@@ -44,7 +44,8 @@ void main() {
         ),
       );
 
-      expect(find.text('No routine loaded'), findsOneWidget);
+      // Both columns show "No routine loaded" when no data is present
+      expect(find.text('No routine loaded'), findsNWidgets(2));
 
       bloc.close();
     });
@@ -68,10 +69,11 @@ void main() {
 
       // Should show task list
       expect(find.byType(ReorderableListView), findsOneWidget);
-      expect(find.text('Morning Workout'), findsOneWidget);
-      expect(find.text('Shower'), findsOneWidget);
-      expect(find.text('Breakfast'), findsOneWidget);
-      expect(find.text('Review Plan'), findsOneWidget);
+      // Tasks appear in both the list and the settings panel, so we check for at least one
+      expect(find.text('Morning Workout'), findsAtLeastNWidgets(1));
+      expect(find.text('Shower'), findsAtLeastNWidgets(1));
+      expect(find.text('Breakfast'), findsAtLeastNWidgets(1));
+      expect(find.text('Review Plan'), findsAtLeastNWidgets(1));
 
       bloc.close();
     });
@@ -149,7 +151,7 @@ void main() {
       bloc.close();
     });
 
-    testWidgets('displays right column placeholder', (tester) async {
+    testWidgets('displays right column with settings panel', (tester) async {
       final bloc = RoutineBloc();
 
       await tester.pumpWidget(
@@ -162,10 +164,8 @@ void main() {
         ),
       );
 
-      expect(
-        find.text('Right Column: Settings & Details Placeholder'),
-        findsOneWidget,
-      );
+      // Should show "No routine loaded" in both columns initially
+      expect(find.text('No routine loaded'), findsNWidgets(2));
 
       bloc.close();
     });

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -38,12 +38,11 @@ void main() {
     expect(find.text('Task Management'), findsOneWidget);
     // Left column should show a reorderable task list with sample data
     expect(find.byType(ReorderableListView), findsOneWidget);
-    expect(find.text('Morning Workout'), findsOneWidget);
-    // Right column placeholder should still be present
-    expect(
-      find.text('Right Column: Settings & Details Placeholder'),
-      findsOneWidget,
-    );
+    // Task appears in both the list and the settings panel
+    expect(find.text('Morning Workout'), findsAtLeastNWidgets(1));
+    // Right column should show settings panel sections
+    expect(find.text('Routine Settings'), findsOneWidget);
+    expect(find.text('Task Details'), findsOneWidget);
   });
 
   testWidgets('Can navigate to Main Routine via the test menu', (tester) async {


### PR DESCRIPTION
Implement the Task Management Screen's right-hand settings panel to allow users to configure routine settings and edit, duplicate, or delete tasks.

---
<a href="https://cursor.com/background-agent?bcId=bc-7079cc3d-7ba6-437e-8129-4e3808732fe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7079cc3d-7ba6-437e-8129-4e3808732fe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

