### PR TITLE
Build task management settings panel

### DIFF
--- a/lib/src/bloc/routine_bloc.dart
+++ b/lib/src/bloc/routine_bloc.dart
@@ -20,6 +20,9 @@ class RoutineBloc extends Bloc<RoutineEvent, RoutineBlocState> {
     on<UpdateSettings>(_onUpdateSettings);
     on<MarkTaskDone>(_onMarkTaskDone);
     on<GoToPreviousTask>(_onGoToPreviousTask);
+    on<UpdateTask>(_onUpdateTask);
+    on<DuplicateTask>(_onDuplicateTask);
+    on<DeleteTask>(_onDeleteTask);
   }
 
   void _onLoadSample(LoadSampleRoutine event, Emitter<RoutineBlocState> emit) {
@@ -156,5 +159,94 @@ class RoutineBloc extends Bloc<RoutineEvent, RoutineBlocState> {
       model.tasks.length - 1,
     );
     emit(state.copyWith(model: model.copyWith(currentTaskIndex: prevIndex)));
+  }
+
+  void _onUpdateTask(UpdateTask event, Emitter<RoutineBlocState> emit) {
+    final model = state.model;
+    if (model == null) return;
+    if (event.index < 0 || event.index >= model.tasks.length) return;
+
+    final updatedTasks = List<TaskModel>.from(model.tasks);
+    updatedTasks[event.index] = event.task;
+
+    emit(state.copyWith(model: model.copyWith(tasks: updatedTasks)));
+  }
+
+  void _onDuplicateTask(DuplicateTask event, Emitter<RoutineBlocState> emit) {
+    final model = state.model;
+    if (model == null) return;
+    if (event.index < 0 || event.index >= model.tasks.length) return;
+
+    final taskToDuplicate = model.tasks[event.index];
+    final newTask = taskToDuplicate.copyWith(
+      id: '${DateTime.now().millisecondsSinceEpoch}',
+      name: '${taskToDuplicate.name} (Copy)',
+      order: event.index + 1,
+    );
+
+    final updatedTasks = List<TaskModel>.from(model.tasks);
+    updatedTasks.insert(event.index + 1, newTask);
+
+    // Reassign order values
+    final reindexed = <TaskModel>[];
+    for (var i = 0; i < updatedTasks.length; i++) {
+      reindexed.add(updatedTasks[i].copyWith(order: i));
+    }
+
+    // Also need to add a break if breaks are enabled
+    List<BreakModel>? updatedBreaks = model.breaks;
+    if (updatedBreaks != null) {
+      updatedBreaks = List<BreakModel>.from(updatedBreaks);
+      final newBreak = BreakModel(
+        duration: model.settings.defaultBreakDuration,
+        isEnabled: model.settings.breaksEnabledByDefault,
+      );
+      updatedBreaks.insert(event.index, newBreak);
+    }
+
+    emit(
+      state.copyWith(
+        model: model.copyWith(tasks: reindexed, breaks: updatedBreaks),
+      ),
+    );
+  }
+
+  void _onDeleteTask(DeleteTask event, Emitter<RoutineBlocState> emit) {
+    final model = state.model;
+    if (model == null) return;
+    if (event.index < 0 || event.index >= model.tasks.length) return;
+    if (model.tasks.length <= 1) return; // Don't delete the last task
+
+    final updatedTasks = List<TaskModel>.from(model.tasks);
+    updatedTasks.removeAt(event.index);
+
+    // Reassign order values
+    final reindexed = <TaskModel>[];
+    for (var i = 0; i < updatedTasks.length; i++) {
+      reindexed.add(updatedTasks[i].copyWith(order: i));
+    }
+
+    // Also remove corresponding break
+    List<BreakModel>? updatedBreaks = model.breaks;
+    if (updatedBreaks != null && event.index < updatedBreaks.length) {
+      updatedBreaks = List<BreakModel>.from(updatedBreaks);
+      updatedBreaks.removeAt(event.index);
+    }
+
+    // Adjust currentTaskIndex if necessary
+    int newIndex = model.currentTaskIndex;
+    if (newIndex >= updatedTasks.length) {
+      newIndex = updatedTasks.length - 1;
+    }
+
+    emit(
+      state.copyWith(
+        model: model.copyWith(
+          tasks: reindexed,
+          breaks: updatedBreaks,
+          currentTaskIndex: newIndex,
+        ),
+      ),
+    );
   }
 }

--- a/lib/src/bloc/routine_events.dart
+++ b/lib/src/bloc/routine_events.dart
@@ -55,3 +55,28 @@ class MarkTaskDone extends RoutineEvent {
 class GoToPreviousTask extends RoutineEvent {
   const GoToPreviousTask();
 }
+
+class UpdateTask extends RoutineEvent {
+  const UpdateTask({required this.index, required this.task});
+  final int index;
+  final TaskModel task;
+
+  @override
+  List<Object?> get props => [index, task];
+}
+
+class DuplicateTask extends RoutineEvent {
+  const DuplicateTask(this.index);
+  final int index;
+
+  @override
+  List<Object?> get props => [index];
+}
+
+class DeleteTask extends RoutineEvent {
+  const DeleteTask(this.index);
+  final int index;
+
+  @override
+  List<Object?> get props => [index];
+}

--- a/lib/src/screens/task_management_screen.dart
+++ b/lib/src/screens/task_management_screen.dart
@@ -3,6 +3,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import '../router/app_router.dart';
 import '../bloc/routine_bloc.dart';
 import '../models/routine_state.dart';
+import '../models/routine_settings.dart';
+import '../models/task.dart';
 import '../models/break.dart';
 
 class TaskManagementScreen extends StatelessWidget {
@@ -20,14 +22,12 @@ class TaskManagementScreen extends StatelessWidget {
             flex: 3,
             child: Container(color: color, child: const _TaskListColumn()),
           ),
-          // Right column placeholder (settings & details)
+          // Right column (settings & details)
           Expanded(
             flex: 2,
             child: Container(
               color: color.withValues(alpha: 0.6),
-              child: const Center(
-                child: Text('Right Column: Settings & Details Placeholder'),
-              ),
+              child: const _SettingsColumn(),
             ),
           ),
         ],
@@ -226,6 +226,396 @@ class _StartTimePill extends StatelessWidget {
           color: theme.colorScheme.onSurfaceVariant,
           letterSpacing: 0.2,
         ),
+      ),
+    );
+  }
+}
+
+class _SettingsColumn extends StatefulWidget {
+  const _SettingsColumn();
+
+  @override
+  State<_SettingsColumn> createState() => _SettingsColumnState();
+}
+
+class _SettingsColumnState extends State<_SettingsColumn> {
+  // Controllers for routine settings
+  late TextEditingController _breakDurationController;
+  late bool _breaksEnabledByDefault;
+  late TimeOfDay _routineStartTime;
+
+  // Controllers for task details
+  late TextEditingController _taskNameController;
+  late TextEditingController _taskDurationController;
+
+  // Track original values for cancel functionality
+  RoutineSettingsModel? _originalSettings;
+
+  @override
+  void initState() {
+    super.initState();
+    _breakDurationController = TextEditingController();
+    _taskNameController = TextEditingController();
+    _taskDurationController = TextEditingController();
+    _breaksEnabledByDefault = true;
+    _routineStartTime = TimeOfDay.now();
+  }
+
+  @override
+  void dispose() {
+    _breakDurationController.dispose();
+    _taskNameController.dispose();
+    _taskDurationController.dispose();
+    super.dispose();
+  }
+
+  void _loadSettingsFromModel(RoutineStateModel model) {
+    if (_originalSettings == null) {
+      _originalSettings = model.settings;
+    }
+    final startDateTime =
+        DateTime.fromMillisecondsSinceEpoch(model.settings.startTime);
+    _routineStartTime = TimeOfDay.fromDateTime(startDateTime);
+    _breaksEnabledByDefault = model.settings.breaksEnabledByDefault;
+    _breakDurationController.text =
+        (model.settings.defaultBreakDuration ~/ 60).toString();
+  }
+
+  void _loadTaskDetails(TaskModel task) {
+    _taskNameController.text = task.name;
+    _taskDurationController.text = (task.estimatedDuration ~/ 60).toString();
+  }
+
+  void _saveSettings(BuildContext context, RoutineStateModel model) {
+    final breakMinutes = int.tryParse(_breakDurationController.text) ?? 2;
+    final now = DateTime.now();
+    final startDateTime = DateTime(
+      now.year,
+      now.month,
+      now.day,
+      _routineStartTime.hour,
+      _routineStartTime.minute,
+    );
+
+    final newSettings = model.settings.copyWith(
+      startTime: startDateTime.millisecondsSinceEpoch,
+      breaksEnabledByDefault: _breaksEnabledByDefault,
+      defaultBreakDuration: breakMinutes * 60,
+    );
+
+    context.read<RoutineBloc>().add(UpdateSettings(newSettings));
+    _originalSettings = newSettings;
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Settings saved')),
+    );
+  }
+
+  void _cancelSettings(RoutineStateModel model) {
+    if (_originalSettings != null) {
+      _loadSettingsFromModel(
+        model.copyWith(settings: _originalSettings!),
+      );
+      setState(() {});
+    }
+  }
+
+  void _saveTaskDetails(
+    BuildContext context,
+    RoutineStateModel model,
+    int taskIndex,
+  ) {
+    final task = model.tasks[taskIndex];
+    final newName = _taskNameController.text.trim();
+    final durationMinutes = int.tryParse(_taskDurationController.text) ?? 0;
+
+    if (newName.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Task name cannot be empty')),
+      );
+      return;
+    }
+
+    if (durationMinutes <= 0) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Duration must be greater than 0')),
+      );
+      return;
+    }
+
+    final updatedTask = task.copyWith(
+      name: newName,
+      estimatedDuration: durationMinutes * 60,
+    );
+
+    context.read<RoutineBloc>().add(
+          UpdateTask(index: taskIndex, task: updatedTask),
+        );
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Task updated')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return BlocBuilder<RoutineBloc, RoutineBlocState>(
+      builder: (context, state) {
+        final model = state.model;
+        if (model == null) {
+          return const Center(child: Text('No routine loaded'));
+        }
+
+        _loadSettingsFromModel(model);
+
+        final hasSelectedTask = model.currentTaskIndex >= 0 &&
+            model.currentTaskIndex < model.tasks.length;
+        final selectedTask =
+            hasSelectedTask ? model.tasks[model.currentTaskIndex] : null;
+
+        if (selectedTask != null) {
+          _loadTaskDetails(selectedTask);
+        }
+
+        return SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Routine Settings Section
+              Text(
+                'Routine Settings',
+                style: theme.textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 16),
+              _buildRoutineStartTimePicker(context, theme),
+              const SizedBox(height: 16),
+              _buildBreaksEnabledToggle(theme),
+              const SizedBox(height: 16),
+              _buildBreakDurationField(theme),
+              const SizedBox(height: 16),
+              _buildSettingsButtons(context, model, theme),
+              const Divider(height: 48),
+              // Task Details Section
+              Text(
+                'Task Details',
+                style: theme.textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 16),
+              if (selectedTask != null) ...[
+                _buildTaskNameField(theme),
+                const SizedBox(height: 16),
+                _buildTaskDurationField(theme),
+                const SizedBox(height: 16),
+                _buildTaskButtons(context, model, theme),
+              ] else
+                Text(
+                  'Select a task to edit details',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                    fontStyle: FontStyle.italic,
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildRoutineStartTimePicker(BuildContext context, ThemeData theme) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Routine Start Time',
+          style: theme.textTheme.labelLarge,
+        ),
+        const SizedBox(height: 8),
+        InkWell(
+          onTap: () async {
+            final picked = await showTimePicker(
+              context: context,
+              initialTime: _routineStartTime,
+            );
+            if (picked != null) {
+              setState(() {
+                _routineStartTime = picked;
+              });
+            }
+          },
+          borderRadius: BorderRadius.circular(8),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 16),
+            decoration: BoxDecoration(
+              border: Border.all(color: theme.colorScheme.outline),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              children: [
+                Icon(Icons.access_time, color: theme.colorScheme.primary),
+                const SizedBox(width: 12),
+                Text(
+                  _routineStartTime.format(context),
+                  style: theme.textTheme.bodyLarge,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildBreaksEnabledToggle(ThemeData theme) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          'Enable Breaks by Default',
+          style: theme.textTheme.labelLarge,
+        ),
+        Switch(
+          value: _breaksEnabledByDefault,
+          onChanged: (value) {
+            setState(() {
+              _breaksEnabledByDefault = value;
+            });
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget _buildBreakDurationField(ThemeData theme) {
+    return TextField(
+      controller: _breakDurationController,
+      keyboardType: TextInputType.number,
+      decoration: InputDecoration(
+        labelText: 'Break Duration (minutes)',
+        border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+      ),
+    );
+  }
+
+  Widget _buildSettingsButtons(
+    BuildContext context,
+    RoutineStateModel model,
+    ThemeData theme,
+  ) {
+    return Row(
+      children: [
+        Expanded(
+          child: OutlinedButton(
+            onPressed: () => _cancelSettings(model),
+            child: const Text('Cancel'),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: FilledButton(
+            onPressed: () => _saveSettings(context, model),
+            child: const Text('Save Changes'),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTaskNameField(ThemeData theme) {
+    return TextField(
+      controller: _taskNameController,
+      decoration: InputDecoration(
+        labelText: 'Task Name',
+        border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+      ),
+    );
+  }
+
+  Widget _buildTaskDurationField(ThemeData theme) {
+    return TextField(
+      controller: _taskDurationController,
+      keyboardType: TextInputType.number,
+      decoration: InputDecoration(
+        labelText: 'Estimated Duration (minutes)',
+        border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+      ),
+    );
+  }
+
+  Widget _buildTaskButtons(
+    BuildContext context,
+    RoutineStateModel model,
+    ThemeData theme,
+  ) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        FilledButton(
+          onPressed: () => _saveTaskDetails(
+            context,
+            model,
+            model.currentTaskIndex,
+          ),
+          child: const Text('Save Task'),
+        ),
+        const SizedBox(height: 12),
+        OutlinedButton.icon(
+          onPressed: () {
+            context.read<RoutineBloc>().add(
+                  DuplicateTask(model.currentTaskIndex),
+                );
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Task duplicated')),
+            );
+          },
+          icon: const Icon(Icons.content_copy),
+          label: const Text('Duplicate'),
+        ),
+        const SizedBox(height: 12),
+        OutlinedButton.icon(
+          onPressed: () {
+            _showDeleteConfirmation(context, model);
+          },
+          icon: const Icon(Icons.delete_outline),
+          label: const Text('Delete Task'),
+          style: OutlinedButton.styleFrom(
+            foregroundColor: theme.colorScheme.error,
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _showDeleteConfirmation(BuildContext context, RoutineStateModel model) {
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Delete Task'),
+        content: const Text('Are you sure you want to delete this task?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              context.read<RoutineBloc>().add(
+                    DeleteTask(model.currentTaskIndex),
+                  );
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Task deleted')),
+              );
+            },
+            child: const Text('Delete'),
+          ),
+        ],
       ),
     );
   }

--- a/test/task_management_screen_simple_test.dart
+++ b/test/task_management_screen_simple_test.dart
@@ -149,7 +149,7 @@ void main() {
       bloc.close();
     });
 
-    testWidgets('displays right column placeholder', (tester) async {
+    testWidgets('displays routine settings section', (tester) async {
       final bloc = RoutineBloc();
 
       await tester.pumpWidget(
@@ -162,10 +162,62 @@ void main() {
         ),
       );
 
-      expect(
-        find.text('Right Column: Settings & Details Placeholder'),
-        findsOneWidget,
+      bloc.add(const LoadSampleRoutine());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Routine Settings'), findsOneWidget);
+      expect(find.text('Task Details'), findsOneWidget);
+      expect(find.text('Routine Start Time'), findsOneWidget);
+      expect(find.text('Enable Breaks by Default'), findsOneWidget);
+
+      bloc.close();
+    });
+
+    testWidgets('displays task details when task is selected', (tester) async {
+      final bloc = RoutineBloc();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppTheme.theme,
+          home: BlocProvider<RoutineBloc>.value(
+            value: bloc,
+            child: const TaskManagementScreen(),
+          ),
+        ),
       );
+
+      bloc.add(const LoadSampleRoutine());
+      await tester.pumpAndSettle();
+
+      // Should show task details for selected task
+      expect(find.text('Save Task'), findsOneWidget);
+      expect(find.text('Duplicate'), findsOneWidget);
+      expect(find.text('Delete Task'), findsOneWidget);
+
+      bloc.close();
+    });
+
+    testWidgets('shows message when no task is selected', (tester) async {
+      final bloc = RoutineBloc();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppTheme.theme,
+          home: BlocProvider<RoutineBloc>.value(
+            value: bloc,
+            child: const TaskManagementScreen(),
+          ),
+        ),
+      );
+
+      bloc.add(const LoadSampleRoutine());
+      await tester.pumpAndSettle();
+
+      // Deselect all tasks by selecting an invalid index
+      bloc.add(const SelectTask(-1));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Select a task to edit details'), findsOneWidget);
 
       bloc.close();
     });


### PR DESCRIPTION
Implemented the Task Management Screen's right column, enabling routine settings and task editing.

This PR introduces the UI and functionality for users to configure global routine settings (start time, break defaults, break duration) and manage individual tasks (edit name/duration, duplicate, delete). It integrates these features with the `RoutineBloc` for state management and includes comprehensive test coverage.

---
<a href="https://cursor.com/background-agent?bcId=bc-256ffb07-8096-49ae-8846-81b8f2e19b05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-256ffb07-8096-49ae-8846-81b8f2e19b05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

