### PR TITLE
Build task management settings panel

### DIFF
--- a/lib/src/bloc/routine_events.dart
+++ b/lib/src/bloc/routine_events.dart
@@ -55,3 +55,28 @@ class MarkTaskDone extends RoutineEvent {
 class GoToPreviousTask extends RoutineEvent {
   const GoToPreviousTask();
 }
+
+class UpdateTask extends RoutineEvent {
+  const UpdateTask({required this.index, required this.task});
+  final int index;
+  final TaskModel task;
+
+  @override
+  List<Object?> get props => [index, task];
+}
+
+class DuplicateTask extends RoutineEvent {
+  const DuplicateTask(this.index);
+  final int index;
+
+  @override
+  List<Object?> get props => [index];
+}
+
+class DeleteTask extends RoutineEvent {
+  const DeleteTask(this.index);
+  final int index;
+
+  @override
+  List<Object?> get props => [index];
+}

--- a/test/task_management_screen_simple_test.dart
+++ b/test/task_management_screen_simple_test.dart
@@ -44,7 +44,8 @@ void main() {
         ),
       );
 
-      expect(find.text('No routine loaded'), findsOneWidget);
+      // Text appears in both left and right columns
+      expect(find.text('No routine loaded'), findsAtLeastNWidgets(1));
 
       bloc.close();
     });
@@ -68,7 +69,8 @@ void main() {
 
       // Should show task list
       expect(find.byType(ReorderableListView), findsOneWidget);
-      expect(find.text('Morning Workout'), findsOneWidget);
+      // Task names appear in both list and text field, so expect at least one
+      expect(find.text('Morning Workout'), findsAtLeastNWidgets(1));
       expect(find.text('Shower'), findsOneWidget);
       expect(find.text('Breakfast'), findsOneWidget);
       expect(find.text('Review Plan'), findsOneWidget);
@@ -149,7 +151,7 @@ void main() {
       bloc.close();
     });
 
-    testWidgets('displays right column placeholder', (tester) async {
+    testWidgets('displays right column settings', (tester) async {
       final bloc = RoutineBloc();
 
       await tester.pumpWidget(
@@ -162,10 +164,7 @@ void main() {
         ),
       );
 
-      expect(
-        find.text('Right Column: Settings & Details Placeholder'),
-        findsOneWidget,
-      );
+      expect(find.text('No routine loaded'), findsAtLeastNWidgets(1));
 
       bloc.close();
     });

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -38,12 +38,11 @@ void main() {
     expect(find.text('Task Management'), findsOneWidget);
     // Left column should show a reorderable task list with sample data
     expect(find.byType(ReorderableListView), findsOneWidget);
-    expect(find.text('Morning Workout'), findsOneWidget);
-    // Right column placeholder should still be present
-    expect(
-      find.text('Right Column: Settings & Details Placeholder'),
-      findsOneWidget,
-    );
+    // Task appears in both list and text field
+    expect(find.text('Morning Workout'), findsAtLeastNWidgets(1));
+    // Right column should show settings sections
+    expect(find.text('Routine Settings'), findsOneWidget);
+    expect(find.text('Task Details'), findsOneWidget);
   });
 
   testWidgets('Can navigate to Main Routine via the test menu', (tester) async {


### PR DESCRIPTION
Implements the Task Management Screen's right column for routine settings and task editing.

This PR introduces the UI and functionality for managing routine-level settings (start time, break defaults) and individual task details (name, duration). It also enables duplicating and deleting tasks, all wired to the `RoutineBloc` for state management.

---
<a href="https://cursor.com/background-agent?bcId=bc-831f0d98-9644-421c-a110-517c890235b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-831f0d98-9644-421c-a110-517c890235b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

