### PR TITLE
Set default start time to 6am

### DIFF
--- a/lib/src/bloc/routine_bloc.dart
+++ b/lib/src/bloc/routine_bloc.dart
@@ -59,8 +59,12 @@ class RoutineBloc extends Bloc<RoutineEvent, RoutineBlocState> {
       ),
     ];
 
+    // Set default start time to 6am today
+    final now = DateTime.now();
+    final sixAm = DateTime(now.year, now.month, now.day, 6, 0);
+
     final settings = RoutineSettingsModel(
-      startTime: DateTime.now().millisecondsSinceEpoch,
+      startTime: sixAm.millisecondsSinceEpoch,
       breaksEnabledByDefault: true,
       defaultBreakDuration: 2 * 60,
     );

--- a/test/src/bloc/routine_bloc_test.dart
+++ b/test/src/bloc/routine_bloc_test.dart
@@ -14,6 +14,26 @@ void main() {
       expect(loaded.model!.currentTaskIndex, 0);
     });
 
+    test('loads sample routine with default start time at 6am', () async {
+      final bloc = RoutineBloc();
+      bloc.add(const LoadSampleRoutine());
+
+      final loaded = await bloc.stream.firstWhere((s) => s.model != null);
+
+      // Verify start time is set to 6am today
+      final startTime = DateTime.fromMillisecondsSinceEpoch(
+        loaded.model!.settings.startTime,
+      );
+      final now = DateTime.now();
+      final expectedSixAm = DateTime(now.year, now.month, now.day, 6, 0);
+
+      expect(startTime.year, expectedSixAm.year);
+      expect(startTime.month, expectedSixAm.month);
+      expect(startTime.day, expectedSixAm.day);
+      expect(startTime.hour, 6);
+      expect(startTime.minute, 0);
+    });
+
     test('toggle break flips enabled state', () async {
       final bloc = RoutineBloc()..add(const LoadSampleRoutine());
       final initial = await bloc.stream.firstWhere((s) => s.model != null);


### PR DESCRIPTION
Set the default start time for new routines to 6am.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3b395f3-d6c9-40b5-9b26-dfc14a387aae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a3b395f3-d6c9-40b5-9b26-dfc14a387aae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

